### PR TITLE
Triggered by: check name exists otherwise use username

### DIFF
--- a/Script/ViewModels/MainBuildViewModel.js
+++ b/Script/ViewModels/MainBuildViewModel.js
@@ -5,7 +5,7 @@
 
         self.triggeredBy = ko.computed(function () {
             if(self.triggered && self.triggered.user)
-                return self.triggered.user.name();
+                return self.triggered.user.username();
             return null;
         });
 

--- a/Script/ViewModels/MainBuildViewModel.js
+++ b/Script/ViewModels/MainBuildViewModel.js
@@ -4,8 +4,12 @@
         var self = this;
 
         self.triggeredBy = ko.computed(function () {
-            if(self.triggered && self.triggered.user)
+            if(self.triggered && self.triggered.user && self.triggered.user.name)
+                return self.triggered.user.name();
+
+            if(self.triggered && self.triggered.user && self.triggered.user.username)
                 return self.triggered.user.username();
+
             return null;
         });
 


### PR DESCRIPTION
User's name property does not always exist in the json object if the team city associated profile has a user name that is blank.
