### PR TITLE
Fix 400 Bad request in TeamCity 9.X

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -34,4 +34,4 @@ Settings.buildsUrl = Settings.proxy + Settings.teamCityUrl + '/guestAuth/app/res
 Settings.buildTypesUrl = Settings.proxy + Settings.teamCityUrl + '/guestAuth/app/rest/buildTypes';
 
 //The url for the status of the build on the main branch
-Settings.buildStatusUrl = Settings.proxy + Settings.teamCityUrl + '/guestAuth/app/rest/builds/branch:' + Settings.mainBranch + ',running:any,canceled:any';
+Settings.buildStatusUrl = Settings.proxy + Settings.teamCityUrl + '/guestAuth/app/rest/builds/branch:' + Settings.mainBranch + ',running:any,canceled:any?';


### PR DESCRIPTION
9.X stopped tolerating the '&ts=', which tc-radiate adds to bust the cache, because there is no '?' in the URL

This is a better fix than https://github.com/RobBollons/tc-radiate/pull/5/files . That one only fixed the left side list, but left the main branch status on right side broken.
